### PR TITLE
feat: Add location data and database retry logic

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,5 +14,7 @@ model users {
   name      String   @db.VarChar(16)
   region    String   @db.VarChar(32)
   messages  String   @db.VarChar(128)
+  lat       Float?
+  lot       Float?
   createdAt DateTime @default(now())
 }


### PR DESCRIPTION
This commit introduces two main enhancements:
1.  The `users` model in the Prisma schema has been updated to include optional `lat` and `lot` fields to store location data. The `/send` endpoint is updated to handle these new fields.
2.  A retry mechanism has been implemented for all Prisma database queries. This makes the application more resilient to transient database connection errors (like P1001).

Additionally, this commit includes a fix for a database migration drift issue by aligning the local schema and creating a dummy migration file to sync with the database's history.